### PR TITLE
fix(ci): trigger deploy on main

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -3,7 +3,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - master
+      - main
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- change deploy workflow trigger branch from master to main
- keep workflow_dispatch and gh-pages deployment behavior unchanged

## Why
Default branch is now main, so pushes to main should trigger deploy.
