### PR TITLE
fix(ci): remove Node 20 deprecation warnings

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 'latest'
       


### PR DESCRIPTION
## Summary
- bump ctions/checkout from 4 to 5`n- bump ctions/setup-node from 4 to 5`n- keep existing deploy behavior unchanged

## Why
GitHub runners now warn when Node 20-targeted action versions are forced onto Node 24. This updates the workflow to Node 24-ready major versions.